### PR TITLE
Ajout d'une carte

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9636,6 +9636,11 @@
       "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
       "dev": true
     },
+    "leaflet": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
+      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw=="
+    },
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -14836,7 +14841,7 @@
       }
     },
     "vue-loader-v16": {
-      "version": "npm:vue-loader@16.0.0-beta.9",
+      "version": "16.0.0-beta.9",
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.0.0-beta.9.tgz",
       "integrity": "sha512-mu9pg6554GbXDSO8LlxkQM6qUJzUkb/A0FJc9LgRqnU9MCnhzEXwCt1Zx5NObvFpzs2mH2dH/uUCDwL8Qaz9sA==",
       "dev": true,
@@ -14949,6 +14954,11 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "vue2-leaflet": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/vue2-leaflet/-/vue2-leaflet-2.6.0.tgz",
+      "integrity": "sha512-JG+w9TtNuk1yRpPta+RjzH6J+opdRUPzSo8UuBnwk+a/6XD0f2tsaB6g3D6ZpBgIE4wZA2dbZ0dZFz2ulYMj3A=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "@prb0t/pr": "^1.0.0",
     "core-js": "^3.6.5",
     "diff-match-patch": "^1.0.5",
+    "leaflet": "^1.7.1",
     "papaparse": "^5.3.0",
-    "vue": "^2.6.11"
+    "vue": "^2.6.11",
+    "vue2-leaflet": "^2.6.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~4.5.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -80,6 +80,7 @@
             <file-reader
               :newline="newline"
               @load="handleNewFile($event)"
+              @geojson="geojson = $event"
             ></file-reader>
             <br />
           </li>
@@ -117,6 +118,15 @@
                 href="https://schema.data.gouv.fr/etalab/schema-lieux-covoiturage/latest.html"
                 >schema.data.gouv.fr</a
               >
+              <div
+                class="pt-24"
+                style="cursor: pointer"
+                @click="showMap = true"
+                data-cy="show-the-map-link"
+              >
+                🗺️ Voir la carte
+              </div>
+              <Map v-if="showMap" :geojson="geojson"></Map>
             </span>
             <span v-else-if="validFile === false">
               <span style="color: red">❌</span> Le fichier n'est pas valide
@@ -153,12 +163,14 @@
 import DiffMatchPatch from "diff-match-patch";
 import PR from "./components/PR";
 import FileReader from "./components/FileReader";
+import Map from "./components/Map";
 
 export default {
   name: "App",
   components: {
     PR,
     FileReader,
+    Map
   },
   data() {
     return {
@@ -169,7 +181,9 @@ export default {
       newFile: "",
       prUrl: "",
       validFile: undefined,
-      fileAvailable: undefined
+      fileAvailable: undefined,
+      geojson: {},
+      showMap: false
     };
   },
   methods: {
@@ -187,6 +201,7 @@ export default {
       this.newFile = ""
       this.prUrl = ""
       this.validFile = undefined
+      this.showMap = false
     },
     handleNewFile(newFileContent) {
       this.resetAll();

--- a/src/components/FileReader.vue
+++ b/src/components/FileReader.vue
@@ -12,6 +12,7 @@
 <script>
 import papa from "papaparse";
 import { fillCovoiturageIds } from "@/utils/fillId.js";
+import { createGeoJSON } from "@/utils/createGeoJSON.js";
 
 export default {
   data() {
@@ -31,6 +32,7 @@ export default {
       reader.onload = e => {
         let p = papa.parse(e.target.result);
         try {
+          const geojson = createGeoJSON(p.data);
           p.data = fillCovoiturageIds(p.data);
           let content = papa.unparse(p, {
             quotes: true,
@@ -38,6 +40,7 @@ export default {
             skipEmptyLines: "greedy"
           });
           this.$emit("load", content);
+          this.$emit("geojson", geojson);
         } catch (error) {
           this.errorMsg = error;
         }

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -1,0 +1,89 @@
+<template>
+  <l-map
+    data-cy="map"
+    ref="map"
+    style="height: 400px; width: 100%"
+    :zoom="3"
+    :bounds="bounds"
+  >
+    <l-tile-layer :url="url"></l-tile-layer>
+    <l-geo-json
+      ref="geojson"
+      :geojson="geojson"
+      :options="options"
+      :options-style="styleFunction"
+    />
+  </l-map>
+</template>
+
+<script>
+import "leaflet/dist/leaflet.css";
+import L from "leaflet";
+import { LMap, LTileLayer, LGeoJson } from "vue2-leaflet";
+
+export default {
+  components: {
+    LMap,
+    LTileLayer,
+    LGeoJson
+  },
+  data() {
+    return {
+      url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+      fillColor: { emptyId: "#ffbf00", withId: "blue" },
+      bounds: [
+        [40.712, -74.227],
+        [40.774, -74.125]
+      ]
+    };
+  },
+  props: ["geojson"],
+  methods: {},
+  mounted() {
+    this.$nextTick(() => {
+      this.bounds = this.$refs.geojson.mapObject.getBounds();
+    });
+  },
+  computed: {
+    options() {
+      return {
+        pointToLayer: this.pointToLayer,
+        onEachFeature: this.onEachFeatureFunction
+      };
+    },
+    pointToLayer() {
+      return function(geoJsonPoint, latlng) {
+        return L.circleMarker(latlng, {
+          radius: 5
+        });
+      };
+    },
+    styleFunction() {
+      return feature => {
+        const [fillColor, fillOpacity] = feature.properties.emptyId
+          ? [this.fillColor.emptyId, 1]
+          : [this.fillColor.withId, 0.5];
+        return {
+          weight: 0,
+          fillColor: fillColor,
+          fillOpacity: fillOpacity
+        };
+      };
+    },
+    onEachFeatureFunction() {
+      return (feature, layer) => {
+        if (feature.properties.emptyId) {
+          layer.bindPopup(
+            `Aire dont l'identifiant va être généré automatiquement <br> Nom de l'aire : ${feature.properties.name}`
+          );
+        } else {
+          layer.bindPopup(`Nom de l'aire : ${feature.properties.name}`);
+        }
+      };
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/src/utils/createGeoJSON.js
+++ b/src/utils/createGeoJSON.js
@@ -1,0 +1,29 @@
+export function createGeoJSON(data) {
+    const headers = data[0]
+    const idColumnIndex = headers.indexOf('id_lieu')
+    const nameColumnIndex = headers.indexOf('nom_lieu')
+    const lonColumnIndex = headers.indexOf('Xlong')
+    const latColumnIndex = headers.indexOf('Ylat')
+    let features = []
+    for (const [index, row] of data.entries()) {
+        if (index > 0 && row.length > 1) {
+            const emptyId = row[idColumnIndex] === ''
+            const feature = {
+                type: "Feature",
+                properties: { emptyId: emptyId, name: row[nameColumnIndex] },
+                geometry: {
+                    type: "Point",
+                    coordinates: [
+                        parseFloat(row[lonColumnIndex]),
+                        parseFloat(row[latColumnIndex])
+                    ]
+                }
+            }
+            features.push(feature)
+        }
+    }
+    return {
+        type: "FeatureCollection",
+        features: features
+    }
+}

--- a/tests/e2e/specs/test.js
+++ b/tests/e2e/specs/test.js
@@ -11,9 +11,6 @@ describe('valid file upload', () => {
     cy.get('[data-cy="is-file-valid"]').contains('Le fichier est valide')
     cy.get('[data-cy="request-modification-form"]').contains('Soumettre la demande de modification')
     cy.get('[data-cy="submit-button"]').contains('Envoyer')
-
-    
-
   })
 })
 
@@ -36,5 +33,17 @@ describe('upload file with invalid insee code', () => {
     cy.get('[data-cy="show-file-processing-errors"]').contains('Erreur : ')
     cy.get('[data-cy="request-modification-form"]').should('not.exist')
     cy.get('[data-cy="submit-button"]').should('not.exist')
+  })
+})
+
+describe('test the map', () => {
+  it('checks the map exists', () => {
+    cy.reload()
+    const valid_db_fixture = 'valid-base-empty-lines.csv';
+    cy.get('[data-cy="file-input"]').attachFile(valid_db_fixture);
+    cy.get('[data-cy="show-the-map-link"]').contains('Voir la carte')
+    cy.get('[data-cy="map"]').should('not.exist')
+    cy.get('[data-cy="show-the-map-link"]').click()
+    cy.get('[data-cy="map"]').find('path.leaflet-interactive').should('have.length', 1)
   })
 })

--- a/tests/unit/createGeoJSON.spec.js
+++ b/tests/unit/createGeoJSON.spec.js
@@ -1,0 +1,39 @@
+import { createGeoJSON } from '@/utils/createGeoJSON.js'
+
+const data = [
+    ['id_lieu', 'insee', 'nom_lieu', 'Xlong', 'Ylat'],
+    ['75013-C-001', '75013', 'aire1', '2.5', '48'],
+    ['', '75013', 'aire2', '2.51', '48.1'],
+    [''],
+    [],
+]
+
+test('create the GeoJSON from the parsed csv', () => {
+    expect(createGeoJSON(data)).toEqual({
+        type: "FeatureCollection",
+        features: [
+            {
+                type: "Feature",
+                properties: { emptyId: false, name: 'aire1' },
+                geometry: {
+                    type: "Point",
+                    coordinates: [
+                        2.5,
+                        48
+                    ]
+                }
+            },
+            {
+                type: "Feature",
+                properties: { emptyId: true, name: 'aire2' },
+                geometry: {
+                    type: "Point",
+                    coordinates: [
+                        2.51,
+                        48.1
+                    ]
+                }
+            }
+        ]
+    })
+})


### PR DESCRIPTION
Ajout d'une carte permettant de visualiser la base avant sa publication.
Les aires dont l'id va être rempli par l'outil apparaissent en orange, tandis que les autres sont en bleu.