### PR TITLE
Add download link to debug file

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -81,6 +81,7 @@
               :newline="newline"
               @load="handleNewFile($event)"
               @geojson="geojson = $event"
+              @filledFileUrl="filledFileUrl = $event"
             ></file-reader>
             <br />
           </li>
@@ -130,13 +131,19 @@
             </span>
             <span v-else-if="validFile === false">
               <span style="color: red">❌</span> Le fichier n'est pas valide
-              selon schema.data.gouv.fr. Pour en savoir plus sur les erreurs de
-              la validation détectées, rendez-vous sur
-              <a
-                href="https://validata.etalab.studio/table-schema?schema_url=https://schema.data.gouv.fr/schemas/etalab/schema-lieux-covoiturage/0.2.0/schema.json"
-                >cette page</a
-              >
-              et validez vos données. Vous aurez accès à un rapport d'erreur.
+              selon schema.data.gouv.fr. 
+              
+              <div class="pt-24">
+                Pour en savoir plus sur les erreurs de
+                la validation détectées :
+                <ul>
+                  <li>téléchargez <a :href=filledFileUrl>ce fichier</a> (identique à celui que vous avez chargé, avec la colonne id_lieu remplie) </li>
+                  <li>et validez le sur <a
+                  href="https://validata.etalab.studio/table-schema?schema_url=https://schema.data.gouv.fr/schemas/etalab/schema-lieux-covoiturage/0.2.0/schema.json"
+                  target="_blank">cette page</a>.</li>
+                </ul>
+                Vous aurez accès à un rapport d'erreur.
+              </div>
             </span>
             <span v-else>
               Validation du fichier par schema.data.gouv.fr
@@ -183,7 +190,8 @@ export default {
       validFile: undefined,
       fileAvailable: undefined,
       geojson: {},
-      showMap: false
+      showMap: false,
+      filledFileUrl: ""
     };
   },
   computed: {

--- a/src/components/FileReader.vue
+++ b/src/components/FileReader.vue
@@ -30,6 +30,7 @@ export default {
 
       // console.log("file:", file);
       reader.onload = e => {
+        this.errorMsg = ""
         let p = papa.parse(e.target.result);
         try {
           const geojson = createGeoJSON(p.data);
@@ -39,6 +40,10 @@ export default {
             newline: this.newline,
             skipEmptyLines: "greedy"
           });
+          let blob = new Blob([content], { type: "text/csv" });
+          let downloadConvertedFileUrl = window.URL.createObjectURL(blob);
+
+          this.$emit("filledFileUrl", downloadConvertedFileUrl);
           this.$emit("load", content);
           this.$emit("geojson", geojson);
         } catch (error) {


### PR DESCRIPTION
Problème soulevé par Miryad : Lorsqu'on upload un fichier et qu'il contient des erreurs, on a du mal à comprendre pourquoi. En effet on ne peut pas aller sur validata et soumettre le fichier car les id sont manquants et que ces ids manquants peuvent masquer le vrai problème de données dans le fichier.

Donc en cas d'erreur de validation, un lien est disponible pour télécharger le fichier dont les id ont été remplis par l'outil, ce qui permet d'aller sur validata le vaider et comprendre l'origine du probleme.