### PR TITLE
Corrige erreur possible en générant id_lieu

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,20 +4,20 @@ orbs:
   # version "s.x.y" of the orb. We recommend you then use
   # the strict explicit version "cypress-io/cypress@3.x.y"
   # to lock the version and prevent unexpected CI changes
-  cypress: cypress-io/cypress@3
+  cypress: cypress-io/cypress@3.1.3
   jest: blimmer/jest@1.1.1
 
 jobs:
   check-node-version:
     docker:
-      - image: cimg/base:2021.04
+      - image: cimg/base:2023.08
     steps:
       - checkout
       - run: >
-          if [ "$(grep -oP '(?<=nodejs\s).*' .tool-versions)" = "$(cat .node-version)" ]; then 
-            exit 0 
-          else 
-            exit 1 
+          if [ "$(grep -oP '(?<=nodejs\s).*' .tool-versions)" = "$(cat .node-version)" ]; then
+            exit 0
+          else
+            exit 1
           fi
 
 workflows:

--- a/src/App.cy.js
+++ b/src/App.cy.js
@@ -42,7 +42,7 @@ describe('invalid file upload', () => {
       body: "",
     })
     cy.get('[data-cy="file-input"]').selectFile('cypress/fixtures/invalid-insee-code.csv');
-    cy.get('[data-cy="show-file-processing-errors"]').contains('pas un code insee valide')
+    cy.get('[data-cy="show-file-processing-errors"]').contains('pas un code INSEE valide')
     cy.get('[data-cy="request-modification-form"]').should('not.exist')
     cy.get('[data-cy="submit-button"]').should('not.exist')
   })

--- a/src/components/FileReader.vue
+++ b/src/components/FileReader.vue
@@ -54,7 +54,7 @@ export default {
           this.$emit("load", content);
           this.$emit("geojson", geojson);
         } catch (error) {
-          this.errorMsg = "Impossible de lire le fichier envoyé. Veuillez utiliser LibreOffice Calc avec l'encodage UTF-8.";
+          this.errorMsg = error;
           this.$emit("load", undefined);
         }
       };

--- a/src/utils/fillId.js
+++ b/src/utils/fillId.js
@@ -8,10 +8,10 @@ export function extractCountFromId(id) {
 
 export function createIdFromCount(insee, count) {
     if (insee.length !== inseeCodeSize) {
-        throw `${insee} n'est pas un code insee valide !`
+        throw `Le code INSEE \`${insee}\` dans votre fichier n'est pas un code INSEE valide.`
     }
     if (count > 999) {
-        throw `Il y a plus que 999 aires pour le code insee ${insee}, ce qui n'est pas autorisé !`
+        throw `Il y a plus que 999 aires pour le code INSEE ${insee}, ce qui n'est pas autorisé.`
     }
     return `${insee}-C-${count.toString().padStart(3, '0')}`
 }
@@ -31,7 +31,7 @@ export function fillCovoiturageIds(data) {
                 } else {
                     // the row is not empty, but the insee code is missing
                     // that's an error
-                    throw `Code insee manquant ligne ${index + 1}.`
+                    throw `Code INSEE manquant ligne ${index + 1}.`
                 }
             }
             const rowId = row[IdColumnIndex]


### PR DESCRIPTION
Avec un CSV contenant un mauvais code INSEE (sans `0` initial par exemple), le message d'erreur affiché n'était pas le bon.

Cette erreur survient avant la validation avec Validata, à l'étape où on génère automatiquement la code `id_lieu`. Le code en charge de ceci procède à des vérifications simples concernant le code INSEE.

![image](https://github.com/etalab/transport-community-contributions/assets/295709/96311a4a-e042-404c-992b-7ae7393971f0)
